### PR TITLE
Errors in denoiser demo notebook

### DIFF
--- a/notebooks/denoiser/demo.ipynb
+++ b/notebooks/denoiser/demo.ipynb
@@ -20,7 +20,16 @@
    "execution_count": 1,
    "id": "fae635ac-e4cd-4054-932d-64731b851448",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/daniel/.local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import torch\n",
@@ -48,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "7ef4cdb6-deef-4a58-9799-fd3b6f38e954",
    "metadata": {},
    "outputs": [],
@@ -90,20 +99,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "e7fa288e-1b0f-417e-a7b7-3e5a1f024764",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'graphite.transforms.periodic_radius_graph_ase'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mtorch_geometric\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mdata\u001b[39;00m \u001b[39mimport\u001b[39;00m Data, Dataset\n\u001b[1;32m      2\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39msklearn\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mpreprocessing\u001b[39;00m \u001b[39mimport\u001b[39;00m LabelEncoder\n\u001b[0;32m----> 3\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mgraphite\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mtransforms\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mperiodic_radius_graph_ase\u001b[39;00m \u001b[39mimport\u001b[39;00m PeriodicRadiusGraph_ase\n\u001b[1;32m      5\u001b[0m \u001b[39mclass\u001b[39;00m \u001b[39mPeriodicStructureDataset\u001b[39;00m(Dataset):\n\u001b[1;32m      6\u001b[0m     \u001b[39mdef\u001b[39;00m \u001b[39m__init__\u001b[39m(\u001b[39mself\u001b[39m, atoms_list, large_cutoff, duplicate\u001b[39m=\u001b[39m\u001b[39m128\u001b[39m):\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'graphite.transforms.periodic_radius_graph_ase'"
+     ]
+    }
+   ],
    "source": [
     "from torch_geometric.data import Data, Dataset\n",
     "from sklearn.preprocessing import LabelEncoder\n",
-    "from graphite.transforms.periodic_radius_graph_ase import PeriodicRadiusGraph_ase\n",
+    "from graphite.transforms.periodic_radius_graph import PeriodicRadiusGraph\n",
     "\n",
     "class PeriodicStructureDataset(Dataset):\n",
     "    def __init__(self, atoms_list, large_cutoff, duplicate=128):\n",
     "        super().__init__(None, transform=None, pre_transform=None)\n",
     "        \n",
-    "        self.radius_graph = PeriodicRadiusGraph_ase(cutoff=large_cutoff)\n",
+    "        self.radius_graph = PeriodicRadiusGraph(cutoff=large_cutoff)\n",
     "        self.dataset = []\n",
     "        for atoms in atoms_list:\n",
     "            x = LabelEncoder().fit_transform(atoms.numbers)\n",
@@ -650,7 +671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/graphite/transforms/periodic_radius_graph.py
+++ b/src/graphite/transforms/periodic_radius_graph.py
@@ -16,7 +16,7 @@ class PeriodicRadiusGraph(BaseTransform):
         self.cutoff = cutoff
     
     def __call__(self, data):
-        pos, box = data.pos, data.box
+        pos, box = data.pos, data.cell.diag()
         edge_index, edge_vec = periodic_radius_graph(pos, box, self.cutoff)
         data.edge_index = edge_index
         data.edge_attr  = edge_vec


### PR DESCRIPTION
When I tried running the demo notebook I encountered 2 different errors which I hopefully managed to resolve. 

# My environment:
M1 Mac

> sys.version
> '3.10.12 | packaged by conda-forge | (main, Jun 23 2023, 22:41:52) [Clang 15.0.7 ]'
>  torch.__version__
> '1.13.1'
> torch_geometric.__version__
> '2.3.1'

# Error 1

When running the 3rd cell I get the following error:
 
> ModuleNotFoundError                       Traceback (most recent call last)
> Cell In[7], line 3
>       1 from torch_geometric.data import Data, Dataset
>       2 from sklearn.preprocessing import LabelEncoder
> ----> 3 from graphite.transforms.periodic_radius_graph_ase import PeriodicRadiusGraph_ase
>       5 class PeriodicStructureDataset(Dataset):
>       6     def __init__(self, atoms_list, large_cutoff, duplicate=128):
> 
> ModuleNotFoundError: No module named 'graphite.transforms.periodic_radius_graph_ase'

I was able to resolve this error by removing the `_ase` suffix for both `graphite.transforms.periodic_radius_graph_ase` and `PeriodicRadiusGraph_ase`.

# Error 2

Running the next cell gives me this error:

> KeyError                                  Traceback (most recent call last)
> File [~/.local/lib/python3.10/site-packages/torch_geometric/data/storage.py:79](https://file+.vscode-resource.vscode-cdn.net/Users/daniel/Work/ovito_plugins/graphite/notebooks/denoiser/~/.local/lib/python3.10/site-packages/torch_geometric/data/storage.py:79), in BaseStorage.__getattr__(self, key)
>      78 try:
> ---> 79     return self[key]
>      80 except KeyError:
> 
> File [~/.local/lib/python3.10/site-packages/torch_geometric/data/storage.py:104](https://file+.vscode-resource.vscode-cdn.net/Users/daniel/Work/ovito_plugins/graphite/notebooks/denoiser/~/.local/lib/python3.10/site-packages/torch_geometric/data/storage.py:104), in BaseStorage.__getitem__(self, key)
>     103 def __getitem__(self, key: str) -> Any:
> --> 104     return self._mapping[key]
> 
> KeyError: 'box'

This could be resolved by updating the `PeriodicRadiusGraph` class from `data.box` to `data.cell`. 

# Error 3

After this change, the same cell produces a new error:

> RuntimeError                              Traceback (most recent call last)
> Cell In[4], line 10
>       7 LARGE_CUTOFF = 5.0
>       9 # Ad-hoc Dataset class for applying random perturbation and then downselecting graph edges
> ---> 10 dataset = PeriodicStructureDataset(ideal_atoms_list, large_cutoff=LARGE_CUTOFF)
>      12 # Train-validation split
>      13 num_train = int(0.95 * len(dataset))
> 
> Cell In[3], line 20, in PeriodicStructureDataset.__init__(self, atoms_list, large_cutoff, duplicate)
>      12     x = LabelEncoder().fit_transform(atoms.numbers)
>      13     data = Data(
>      14         x       = torch.tensor(x).long(),
>      15         pos     = torch.tensor(atoms.positions).float(),
>    (...)
>      18         numbers = torch.tensor(atoms.numbers).long(),
>      19     )
> ---> 20     data = self.radius_graph(data)
>      21     self.dataset.append(data)
>      22 self.dataset = [d.clone() for d in self.dataset for _ in range(duplicate)]
> 
> File [~/Work/ovito_plugins/graphite/src/graphite/transforms/periodic_radius_graph.py:21](https://file+.vscode-resource.vscode-cdn.net/Users/daniel/Work/ovito_plugins/graphite/notebooks/denoiser/~/Work/ovito_plugins/graphite/src/graphite/transforms/periodic_radius_graph.py:21), in PeriodicRadiusGraph.__call__(self, data)
>      19 def __call__(self, data):
>      20     pos, box = data.pos, data.cell
> ---> 21     edge_index, edge_vec = periodic_radius_graph(pos, box, self.cutoff)
> ...
> ---> 77 coords    = torch.div(pos, cell_dims, rounding_mode='floor').to(torch.long)
>      78 shifts    = cell_shift(coords, shape)
>      80 # If any atom is outside the box, wrap the positions and the cell coordinates back into the box.
> 
> RuntimeError: The size of tensor a (1024) must match the size of tensor b (3) at non-singleton dimension 0

Which can be traced to the same code section and fixed replacing `data.cell` with `data.cell.diag()`. 

# Conclusion 

After these 2 minor changes I was able to use the denoiser as expected.
 
  