### PR TITLE
Pull InitialEmbedding class out of demo.ipynb

### DIFF
--- a/src/graphite/nn/utils/e3nn_initial_embedding.py
+++ b/src/graphite/nn/utils/e3nn_initial_embedding.py
@@ -1,0 +1,23 @@
+from functools import partial
+
+from torch import nn
+
+from graphite.nn.basis import bessel
+
+
+class InitialEmbedding(nn.Module):
+    def __init__(self, num_species, cutoff):
+        super().__init__()
+        self.embed_node_x = nn.Embedding(num_species, 8)
+        self.embed_node_z = nn.Embedding(num_species, 8)
+        self.embed_edge = partial(bessel, start=0.0, end=cutoff, num_basis=16)
+
+    def forward(self, data):
+        # Embed node
+        data.h_node_x = self.embed_node_x(data.x)
+        data.h_node_z = self.embed_node_z(data.x)
+
+        # Embed edge
+        data.h_edge = self.embed_edge(data.edge_attr.norm(dim=-1))
+
+        return data


### PR DESCRIPTION
# Issue

Deploying the pretrained denoiser models in user code requires a manual copy of the InitialEmbedding from the demo notebook.

#  Solution
Adding the InitialEmbedding to the graphite module solves this issue.

# Open questions
I placed the InitialEmbedding in nn/utils/e3nn_initial_embedding trying to mimic the directory/file structure found in nn/models and nn/conv. 
Given your future plans for this project a different file might be more appropriate. 
